### PR TITLE
Add basic `utcdatetime` class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.pyc
+.*.swp
+*__pycache__*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY:test
+test: clean
+	nosetests -sv
+	# coverage run --source=encryptit setup.py test
+	./script/check-pep8.sh utcdatetime/
+	./script/check-todo.sh utcdatetime/
+
+.PHONY: clean
+clean:
+	find . -iname '*.pyc' -delete
+	find . -name __pycache__ -type d -delete
+	rm -rf utcdatettime.egg-info
+	rm -rf dist/ MANIFEST
+	rm -f .coverage
+

--- a/script/check-pep8.sh
+++ b/script/check-pep8.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+THIS_SCRIPT=$0
+THIS_DIR=$(dirname ${THIS_SCRIPT})
+
+DIR_TO_CHECK=$1
+
+
+function run_most_pep8_checks_on_everything {
+    # F401: imported but unused
+    # F403: from foo import *
+
+    flake8 --verbose \
+        --ignore=F401,F403 \
+    ${DIR_TO_CHECK}
+}
+
+function run_particular_pep8_checks_excluding_init_files {
+
+    # F401: don't allow `imported but unused` except in __init__.py
+    flake8 --verbose \
+        --select=F401 \
+        --exclude='*/__init__.py' \
+    ${DIR_TO_CHECK}
+
+    # F403: from xxx import *   - this is OK in __init__.py
+    flake8 --verbose \
+        --select=F403 \
+        --exclude='*/__init__.py' \
+    ${DIR_TO_CHECK}
+}
+
+run_most_pep8_checks_on_everything
+run_particular_pep8_checks_excluding_init_files

--- a/script/check-todo.sh
+++ b/script/check-todo.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+DIR_TO_CHECK=$1
+
+grep -Rin --exclude=*.pyc TODO ${DIR_TO_CHECK}
+
+EXITCODE=$?
+
+if [ "$EXITCODE" = "0" ]; then
+    echo "FAIL: Found one or more TODO entries."
+    exit 1
+
+elif [ "$EXITCODE" = "1" ]; then
+    echo "OK"
+    exit 0
+
+else
+    echo "Error running grep."
+    exit 1
+fi

--- a/utcdatetime/__init__.py
+++ b/utcdatetime/__init__.py
@@ -1,0 +1,2 @@
+from .utc_timezone import UTCTimezone
+from .utcdatetime import utcdatetime, UTC

--- a/utcdatetime/tests/test_construct.py
+++ b/utcdatetime/tests/test_construct.py
@@ -1,0 +1,67 @@
+from nose.tools import assert_raises
+
+
+from utcdatetime import utcdatetime
+
+
+def test_good_constructors():
+    valid_args = [
+        (2015, 6, 30),
+        (2015, 6, 30, 18),
+        (2015, 6, 30, 18, 45),
+        (2015, 6, 30, 18, 45, 37),
+        (2015, 6, 30, 18, 45, 37, 500),
+    ]
+
+    for args in valid_args:
+        yield _assert_can_construct, args
+
+
+def _assert_can_construct(args):
+    utcdatetime(*args)
+
+
+def test_bad_constructors():
+    valid_args = [
+        [],
+        (2015),
+        (2015, 6),
+        (2015, 6, 30),
+        (2015, 6, 30, 18, 45, 37, 500, None),
+    ]
+
+    for args in valid_args:
+        yield assert_raises, TypeError, lambda: utcdatetime(args)
+
+
+def test_valid_month_are_accepted():
+    for month in range(1, 12 + 1):
+        yield _assert_can_construct, (2015, month, 1)
+
+
+def test_invalid_months_are_rejected():
+    for month in [0] + list(range(13, 32)):
+        yield assert_raises, TypeError, (2015, month, 1)
+
+
+def test_invalid_days_are_rejected():
+    invalid_dates = [
+        (2000, 1, 0),
+
+        (2000, 1, 32),
+        (2000, 2, 30),  # leap year
+        (2001, 2, 29),  # non leap year
+        (2000, 3, 32),
+        (2000, 4, 31),
+        (2000, 5, 32),
+        (2000, 6, 31),
+        (2000, 7, 32),
+        (2000, 8, 32),
+        (2000, 9, 31),
+        (2000, 10, 32),
+        (2000, 11, 31),
+        (2000, 12, 32),
+    ]
+
+    for args in invalid_dates:
+        yield assert_raises, ValueError, lambda: utcdatetime(*args)

--- a/utcdatetime/tests/test_repr.py
+++ b/utcdatetime/tests/test_repr.py
@@ -1,0 +1,28 @@
+from nose.tools import assert_equal
+
+from utcdatetime import utcdatetime
+
+TEST_CASES = [
+    ('utcdatetime(2010, 6, 30, 0, 0)',
+     utcdatetime(2010, 6, 30)),
+
+    ('utcdatetime(2010, 6, 30, 18, 0)',
+     utcdatetime(2010, 6, 30, 18)),
+
+    ('utcdatetime(2010, 6, 30, 18, 36)',
+     utcdatetime(2010, 6, 30, 18, 36)),
+
+    ('utcdatetime(2010, 6, 30, 18, 36, 45)',
+     utcdatetime(2010, 6, 30, 18, 36, 45)),
+
+    ('utcdatetime(2010, 6, 30, 18, 36, 45)',
+     utcdatetime(2010, 6, 30, 18, 36, 45)),
+
+    ('utcdatetime(2010, 6, 30, 18, 36, 45, 456)',
+     utcdatetime(2010, 6, 30, 18, 36, 45, 456)),
+]
+
+
+def test_str_method():
+    for expected_repr, utc_datetime in TEST_CASES:
+        yield assert_equal, expected_repr, repr(utc_datetime)

--- a/utcdatetime/tests/test_str.py
+++ b/utcdatetime/tests/test_str.py
@@ -1,0 +1,17 @@
+from nose.tools import assert_equal
+
+from utcdatetime import utcdatetime
+
+TEST_CASES = [
+    ('2010-06-30T00:00:00Z', utcdatetime(2010, 6, 30)),
+    ('2010-06-30T18:00:00Z', utcdatetime(2010, 6, 30, 18)),
+    ('2010-06-30T18:36:00Z', utcdatetime(2010, 6, 30, 18, 36)),
+    ('2010-06-30T18:36:45Z', utcdatetime(2010, 6, 30, 18, 36, 45)),
+    ('2010-06-30T18:36:45Z', utcdatetime(2010, 6, 30, 18, 36, 45)),
+    ('2010-06-30T18:36:45.000456Z', utcdatetime(2010, 6, 30, 18, 36, 45, 456)),
+]
+
+
+def test_str_method():
+    for expected_string, utc_datetime in TEST_CASES:
+        yield assert_equal, expected_string, str(utc_datetime)

--- a/utcdatetime/utc_timezone.py
+++ b/utcdatetime/utc_timezone.py
@@ -1,0 +1,23 @@
+import datetime
+
+
+class UTCTimezone(datetime.tzinfo):
+    """UTC timezone"""
+
+    @staticmethod
+    def utcoffset(dt):
+        return datetime.timedelta(0)
+
+    @staticmethod
+    def tzname(dt):
+        return "UTC"
+
+    @staticmethod
+    def dst(dt):
+        return datetime.timedelta(0)
+
+    @staticmethod
+    def __repr__():
+        return '<UTC>'
+
+UTC = UTCTimezone()

--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -1,0 +1,31 @@
+import datetime
+
+from .utc_timezone import UTC
+
+FORMAT_NO_FRACTION = '%Y-%m-%dT%H:%M:%SZ'
+FORMAT_WITH_FRACTION = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+
+class utcdatetime(object):
+    def __init__(self, year, month, day, hour=0, minute=0, second=0,
+                 microsecond=0):
+        self.__dt = datetime.datetime(year, month, day, hour, minute, second,
+                                      microsecond, tzinfo=UTC)
+
+    def __str__(self):
+        return self.__dt.strftime(
+            FORMAT_WITH_FRACTION if self.__dt.microsecond > 0
+            else FORMAT_NO_FRACTION)
+
+    def __repr__(self):
+        parts = [self.__dt.year, self.__dt.month, self.__dt.day,
+                 self.__dt.hour, self.__dt.minute]
+
+        if self.__dt.second > 0:
+            parts.append(self.__dt.second)
+
+        if self.__dt.microsecond > 0:
+            parts.append(self.__dt.microsecond)
+
+        return 'utcdatetime({})'.format(', '.join(
+            ['{0}'.format(part) for part in parts]))


### PR DESCRIPTION
You can construct it like a datetime:

 ```
utcdatetime.utcdatetime(2015, 6, 20, 17, 37)
```

And it has a reasonable `__str__` and `__repr__`:

```
>>> str(utcdatetime(2015, 6, 20, 17, 37))
'2015-06-20T17:37:00Z'

>>> repr(utcdatetime(2015, 6, 20, 17, 37))
'utcdatetime(2015, 6, 20, 17, 37)'
```

And tests, obviously...