### PR TITLE
Quick fix for incorrect GitHub links in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ setup(
     description='Simple UTC datetimes using RFC3339 subset of ISO8601.',
     author='Paul M Furley',
     author_email='paul@paulfurley.com',
-    url='https://github.com/paulfurley/utcdatetime',
-    download_url=('https://github.com/paulfurley/utcdatetime/tarball/{0}'
+    url='https://github.com/paulfurley/python-utcdatetime',
+    download_url=('https://github.com/paulfurley/python-utcdatetime/tarball/{0}'
                   .format(VERSION)),
     install_requires=get_install_requires(),
     test_suite='nose.collector',


### PR DESCRIPTION
Title says it all, I guess.

Note that this silly little change does make the download link non-PEP8 line length compliant.  Not sure how/if you want to deal with that.

Thanks,

James