### PR TITLE
Add `utcdatetime.from_string(..)` method

### DIFF
--- a/requirements_for_tests.txt
+++ b/requirements_for_tests.txt
@@ -3,3 +3,4 @@ flake8==2.4.0
 pep8==1.5.7
 pyflakes==0.8.1
 coveralls==0.5
+strict-rfc3339==0.5

--- a/utcdatetime/parse_datetime_string.py
+++ b/utcdatetime/parse_datetime_string.py
@@ -1,0 +1,86 @@
+import datetime
+import re
+
+from .utcdatetime import utcdatetime
+
+DATETIME_REGEX = (
+    r'(?P<year>\d{4})'
+    '-'
+    '(?P<month>\d{2})'
+    '-'
+    '(?P<day>\d{2})'
+    'T'
+    '(?P<hour>\d{2})'
+    ':'
+    '(?P<minute>\d{2})'
+    ':'
+    '(?P<second>\d{2})'
+)
+
+FRACTIONAL_SECONDS_REGEX = r'(?P<fractional_second>\.\d+)'
+
+TIMEOFFSET_REGEX = (
+    r'(?P<offset_sign>[+-])'
+    '(?P<offset_hour>\d{2})'
+    ':'
+    '(?P<offset_minute>\d{2})'
+)
+
+REGEXES = [re.compile(x) for x in [
+    (DATETIME_REGEX + 'Z'),
+    (DATETIME_REGEX + FRACTIONAL_SECONDS_REGEX + 'Z'),
+
+    (DATETIME_REGEX + TIMEOFFSET_REGEX),
+    (DATETIME_REGEX + FRACTIONAL_SECONDS_REGEX + TIMEOFFSET_REGEX),
+]]
+
+
+def parse_datetime_string(string):
+    for pattern in REGEXES:
+        match = pattern.match(string)
+        if match is not None:
+            return construct_utcdatetime(match)
+
+    raise ValueError(
+        'Failed to parse `{0}` Is it a valid RFC 3339 string? See '
+        'https://www.ietf.org/rfc/rfc3339.txt'.format(string))
+
+
+def construct_utcdatetime(match):
+    required_args = [
+        int(match.group(x))
+        for x in ('year', 'month', 'day', 'hour', 'minute', 'second')]
+
+    utc_dt = utcdatetime(*required_args)
+
+    try:
+        utc_dt.microsecond = convert_fractional_second(
+            float(match.group('fractional_second')))
+    except IndexError:
+        pass
+
+    try:
+        offset_sign = match.group('offset_sign')
+        offset_hour = int(match.group('offset_hour'))
+        offset_minute = int(match.group('offset_minute'))
+
+    except IndexError:
+        pass
+
+    else:
+        utc_dt -= make_delta(offset_sign, offset_hour, offset_minute)
+
+    return utc_dt
+
+
+def convert_fractional_second(fractional_second):
+    """
+    From a fraction of a second, eg .456, return a number of microseconds.
+    """
+    return int(round(1000000 * float(fractional_second)))
+
+
+def make_delta(offset_sign, offset_hour, offset_minute):
+    plus_minus = int('{0}1'.format(offset_sign))
+    return datetime.timedelta(hours=plus_minus * offset_hour,
+                              minutes=plus_minus * offset_minute)

--- a/utcdatetime/tests/test_from_string.py
+++ b/utcdatetime/tests/test_from_string.py
@@ -1,0 +1,91 @@
+import itertools
+from nose.tools import assert_equal
+
+import strict_rfc3339
+
+
+from utcdatetime import utcdatetime
+from utcdatetime.parse_datetime_string import make_delta
+
+
+BASE_DATES = ['2010-01-23T18:30:21']
+
+SECONDS_FRACTIONS = [
+    '',      # no fractional part
+    '.456',
+    '.000456',
+]
+
+TIMEZONES = [
+    'Z',
+    '+00:00',
+    '+01:00',
+    '-01:00',
+]
+
+
+EXPECTED = {
+    '2010-01-23T18:30:21Z': utcdatetime(2010, 1, 23, 18, 30, 21),
+    '2010-01-23T18:30:21.456Z': utcdatetime(2010, 1, 23, 18, 30, 21, 456000),
+    '2010-01-23T18:30:21.000456Z': utcdatetime(2010, 1, 23, 18, 30, 21, 456),
+
+    '2010-01-23T18:30:21+00:00':
+    utcdatetime(2010, 1, 23, 18, 30, 21),
+
+    '2010-01-23T18:30:21.456+00:00':
+    utcdatetime(2010, 1, 23, 18, 30, 21, 456000),
+
+    '2010-01-23T18:30:21.000456+00:00':
+    utcdatetime(2010, 1, 23, 18, 30, 21, 456),
+
+    '2010-01-23T18:30:21+01:00':
+    utcdatetime(2010, 1, 23, 17, 30, 21),
+
+    '2010-01-23T18:30:21.456+01:00':
+    utcdatetime(2010, 1, 23, 17, 30, 21, 456000),
+
+    '2010-01-23T18:30:21.000456+01:00':
+    utcdatetime(2010, 1, 23, 17, 30, 21, 456),
+
+    '2010-01-23T18:30:21-01:00':
+    utcdatetime(2010, 1, 23, 19, 30, 21),
+
+    '2010-01-23T18:30:21.456-01:00':
+    utcdatetime(2010, 1, 23, 19, 30, 21, 456000),
+
+    '2010-01-23T18:30:21.000456-01:00':
+    utcdatetime(2010, 1, 23, 19, 30, 21, 456),
+}
+
+
+def test_parse_string():
+    for base, seconds_fraction, timezone in itertools.product(
+            BASE_DATES, SECONDS_FRACTIONS, TIMEZONES):
+        datetime_string = '{0}{1}{2}'.format(base, seconds_fraction, timezone)
+
+        assert strict_rfc3339.validate_rfc3339(datetime_string), \
+            'Not RFC3339: {}'.format(datetime_string)  # for sanity
+        yield _assert_datetime_parse_equals, datetime_string, \
+            EXPECTED[datetime_string]
+
+
+def _assert_datetime_parse_equals(datetime_string, expected_utcdatetime):
+    assert_equal(
+        expected_utcdatetime,
+        utcdatetime.from_string(datetime_string))
+
+
+def test_make_delta():
+    cases = [
+        ('+', 1, 0, 3600),
+        ('-', 1, 0, -3600),
+        ('+', 1, 25, 3600 + (25 * 60)),
+        ('-', 1, 25, -3600 - (25 * 60)),
+    ]
+
+    for sign, hour, minute, expected in cases:
+        yield _assert_make_delta_equals, sign, hour, minute, expected
+
+
+def _assert_make_delta_equals(sign, hour, minute, expected):
+    assert_equal(expected, make_delta(sign, hour, minute).total_seconds())

--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -7,6 +7,11 @@ FORMAT_WITH_FRACTION = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 
 class utcdatetime(object):
+    @staticmethod
+    def from_string(string):
+        from .parse_datetime_string import parse_datetime_string
+        return parse_datetime_string(string)
+
     def __init__(self, year, month, day, hour=0, minute=0, second=0,
                  microsecond=0):
         self.__dt = datetime.datetime(year, month, day, hour, minute, second,
@@ -29,3 +34,18 @@ class utcdatetime(object):
 
         return 'utcdatetime({0})'.format(', '.join(
             ['{0}'.format(part) for part in parts]))
+
+    @property
+    def microsecond(self):
+        return self.__dt.microsecond
+
+    @microsecond.setter
+    def microsecond(self, value):
+        self.__dt = self.__dt.replace(microsecond=value)
+
+    def __eq__(self, other):
+        return self.__dt == other.__dt
+
+    def __isub__(self, delta):
+        self.__dt -= delta
+        return self


### PR DESCRIPTION
Aim is to parse any valid RFC 3339 string. I think the test cases cover most
of that, although not leap seconds and perhaps a few other bits.