### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',


### PR DESCRIPTION
It's relatively simple to write Python 3.x code that's backwards compatible 
with Python 2.7.x

It's bloody awkward to do the same for Python 2.6.

As I want to see Python 2.6 die, I'm not going out of my way to help keep it
alive!