### PR TITLE
Add `from_datetime` static method

### DIFF
--- a/requirements_for_tests.txt
+++ b/requirements_for_tests.txt
@@ -4,3 +4,4 @@ pep8==1.5.7
 pyflakes==0.8.1
 coveralls==0.5
 strict-rfc3339==0.5
+pytz==2015.7

--- a/utcdatetime/tests/test_from_datetime.py
+++ b/utcdatetime/tests/test_from_datetime.py
@@ -1,0 +1,34 @@
+import datetime
+import pytz
+
+from nose.tools import assert_equal, assert_raises
+
+from utcdatetime import utcdatetime
+
+UK = pytz.timezone('Europe/London')
+SYDNEY = pytz.timezone('Australia/Sydney')
+
+
+TEST_CASES = [
+    (UK.localize(datetime.datetime(2010, 6, 10, 18, 45)),
+     utcdatetime(2010, 6, 10, 17, 45)),  # note british summer time -> UTC
+
+    (UK.localize(datetime.datetime(2010, 2, 10, 18, 45)),
+     utcdatetime(2010, 2, 10, 18, 45)),  # UK winter time == GMT
+
+    (SYDNEY.localize(datetime.datetime(2015, 12, 2, 7, 30)),
+     utcdatetime(2015, 12, 1, 20, 30)),  # note day shift!
+
+    (SYDNEY.localize(datetime.datetime(2015, 6, 6, 18, 30)),
+     utcdatetime(2015, 6, 6, 8, 30)),  # Sydney winter time
+]
+
+
+def test_that_from_datetime_rejets_naive_datetimes():
+    assert_raises(ValueError, lambda: utcdatetime.from_datetime(
+        datetime.datetime(2015, 10, 10, 13, 45)))
+
+
+def test_from_datetime():
+    for dt, expected_utcdatetime in TEST_CASES:
+        yield assert_equal, expected_utcdatetime, utcdatetime.from_datetime(dt)

--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -12,6 +12,13 @@ class utcdatetime(object):
         from .parse_datetime_string import parse_datetime_string
         return parse_datetime_string(string)
 
+    @staticmethod
+    def from_datetime(dt):
+        dt_utc = dt.astimezone(UTC)
+
+        return utcdatetime(dt_utc.year, dt_utc.month, dt_utc.day, dt_utc.hour,
+                           dt_utc.minute, dt_utc.second, dt_utc.microsecond)
+
     def __init__(self, year, month, day, hour=0, minute=0, second=0,
                  microsecond=0):
         self.__dt = datetime.datetime(year, month, day, hour, minute, second,


### PR DESCRIPTION
So we can create `utcdatetime` objects from conventional `datetime` ones.