### PR TITLE
Add `now()` constructor

### DIFF
--- a/requirements_for_tests.txt
+++ b/requirements_for_tests.txt
@@ -5,3 +5,4 @@ pyflakes==0.8.1
 coveralls==0.5
 strict-rfc3339==0.5
 pytz==2015.7
+freezegun==0.3.5

--- a/utcdatetime/tests/test_now.py
+++ b/utcdatetime/tests/test_now.py
@@ -1,0 +1,23 @@
+import utcdatetime
+
+from nose.tools import assert_equal
+from freezegun import freeze_time
+
+from datetime import datetime
+
+
+TEST_CASES = [
+    (datetime(2015, 5, 11, 16, 43), (2015, 5, 11, 16, 43, 0)),
+]
+
+
+def test_now_method():
+    for local_datetime, expected_utc in TEST_CASES:
+        yield _assert_now_equals, local_datetime, expected_utc
+
+
+def _assert_now_equals(local_datetime, expected_utc):
+    with freeze_time(local_datetime):
+        got = utcdatetime.utcdatetime.now()
+
+    assert_equal(utcdatetime.utcdatetime(*expected_utc), got)

--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -7,17 +7,17 @@ FORMAT_WITH_FRACTION = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 
 class utcdatetime(object):
-    @staticmethod
-    def from_string(string):
+    @classmethod
+    def from_string(cls, string):
         from .parse_datetime_string import parse_datetime_string
         return parse_datetime_string(string)
 
-    @staticmethod
-    def from_datetime(dt):
+    @classmethod
+    def from_datetime(cls, dt):
         dt_utc = dt.astimezone(UTC)
 
-        return utcdatetime(dt_utc.year, dt_utc.month, dt_utc.day, dt_utc.hour,
-                           dt_utc.minute, dt_utc.second, dt_utc.microsecond)
+        return cls(dt_utc.year, dt_utc.month, dt_utc.day, dt_utc.hour,
+                   dt_utc.minute, dt_utc.second, dt_utc.microsecond)
 
     def __init__(self, year, month, day, hour=0, minute=0, second=0,
                  microsecond=0):

--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -19,6 +19,13 @@ class utcdatetime(object):
         return cls(dt_utc.year, dt_utc.month, dt_utc.day, dt_utc.hour,
                    dt_utc.minute, dt_utc.second, dt_utc.microsecond)
 
+    @classmethod
+    def now(cls):
+        """
+        Return the current date and time in the UTC timezone.
+        """
+        return cls.from_datetime(datetime.datetime.now(UTC))
+
     def __init__(self, year, month, day, hour=0, minute=0, second=0,
                  microsecond=0):
         self.__dt = datetime.datetime(year, month, day, hour, minute, second,


### PR DESCRIPTION
Similar to the `datetime` module's `now()` constructor, except that this
doesn't support converting to a timezone - it always gives "now" in UTC.on

Example:
```
>>> import utcdatetime
>>> utcdatetime.utcdatetime.now()
utcdatetime(2015, 12, 3, 20, 52, 50, 483319)
```