### PR TITLE
Add `astimezone` method (passthru)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ Not a problem, as long as it's got a timezone:
 utcdatetime.utcdatetime(2010, 6, 10, 17, 45)  # Note British Summer Time -> UTC
 ```
 
+# Convert a utcdatetime into a Python datetime
+
+```python
+>>> import utcdatetime
+>>> import pytz
+
+>>> my_datetime = utcdatetime.utcdatetime(2010, 6, 10, 17, 45)  # Note British summer time
+>>> my_datetime.astimezone(pytz.timezone('Europe/London'))
+datetime.datetime(2010, 6, 10, 18, 45, tzinfo=<DstTzInfo 'Europe/London' GMT0:00:00 STD>)
+```
+
 # Motivation
 
 I used to work all day with UTC datetimes in Python and I found some baffling things:

--- a/utcdatetime/tests/test_astimezone.py
+++ b/utcdatetime/tests/test_astimezone.py
@@ -1,0 +1,33 @@
+import pytz
+
+from utcdatetime import utcdatetime
+
+from nose.tools import assert_equal
+
+UK = pytz.timezone('Europe/London')
+SYDNEY = pytz.timezone('Australia/Sydney')
+
+
+TEST_CASES = [
+    (utcdatetime(2010, 6, 10, 17, 45),  # note british summer time -> UTC
+     UK,
+     '2010-06-10T18:45:00+01:00'),
+
+    (utcdatetime(2010, 2, 10, 18, 45),  # UK winter time == GMT, no change
+     UK,
+     '2010-02-10T18:45:00+00:00'),
+
+    (utcdatetime(2015, 12, 1, 20, 30),  # note day shift!
+     SYDNEY,
+     '2015-12-02T07:30:00+11:00'),
+
+    (utcdatetime(2015, 6, 6, 8, 30),  # Sydney winter time
+     SYDNEY,
+     '2015-06-06T18:30:00+10:00'),
+]
+
+
+def test_from_datetime():
+    for utc_datetime, timezone, expected_python_datetime in TEST_CASES:
+        got_datetime = utc_datetime.astimezone(timezone)
+        yield assert_equal, expected_python_datetime, got_datetime.isoformat()

--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -26,6 +26,13 @@ class utcdatetime(object):
         """
         return cls.from_datetime(datetime.datetime.now(UTC))
 
+    def astimezone(self, tz):
+        """
+        https://docs.python.org/2/library/datetime.html#datetime.datetime.astimezone
+        Return a Python datetime object with tzinfo attribute tz.
+        """
+        return self.__dt.astimezone(tz)
+
     def __init__(self, year, month, day, hour=0, minute=0, second=0,
                  microsecond=0):
         self.__dt = datetime.datetime(year, month, day, hour, minute, second,


### PR DESCRIPTION
This allows you to get a Python datetime from a utcdatetime:

```
dt = utcdatetime.utcdatetime.now() 
dt.astimezone(pytz.timezone('Europe/London'))
```