### PR TITLE
Support adding and subtracting timedelta

### DIFF
--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -59,6 +59,8 @@ class utcdatetime(object):
     def __eq__(self, other):
         return self.__dt == other.__dt
 
-    def __isub__(self, delta):
-        self.__dt -= delta
-        return self
+    def __add__(self, delta):
+        return self.from_datetime(self.__dt + delta)
+
+    def __sub__(self, delta):
+        return self.from_datetime(self.__dt - delta)

--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -64,3 +64,6 @@ class utcdatetime(object):
 
     def __sub__(self, delta):
         return self.from_datetime(self.__dt - delta)
+
+    def __cmp__(self, other):
+        return cmp(self.astimezone(UTC), other.astimezone(UTC))


### PR DESCRIPTION
The following was not possible before:

    d = utcdatetime.now()
    print d + timedelta(days=1)
    print d - timedelta(days=1)
    d += timedelta(minutes=15)

With this update it is