### PR TITLE
Support add, subtract timedelta & comparison

### DIFF
--- a/utcdatetime/tests/test_add_subtract_compare.py
+++ b/utcdatetime/tests/test_add_subtract_compare.py
@@ -1,6 +1,6 @@
 from nose.tools import (
     assert_equal, assert_not_equal, assert_true, assert_false,
-    assert_is_instance
+    assert_is_instance, assert_raises
 )
 
 from datetime import timedelta
@@ -102,3 +102,7 @@ def test_earlier_minutes_later_returns_negative_timedelta():
     delta = earlier - later
     assert_is_instance(delta, timedelta)
     assert_equal(timedelta(hours=-1), delta)
+
+
+def test_subtracting_inappropriate_type_raises_type_error():
+    assert_raises(TypeError, lambda: utcdatetime(2016, 10, 7, 15, 0) - "foo")

--- a/utcdatetime/tests/test_add_subtract_compare.py
+++ b/utcdatetime/tests/test_add_subtract_compare.py
@@ -1,5 +1,6 @@
 from nose.tools import (
-    assert_equal, assert_not_equal, assert_true, assert_false
+    assert_equal, assert_not_equal, assert_true, assert_false,
+    assert_is_instance
 )
 
 from datetime import timedelta
@@ -83,3 +84,21 @@ def test_utcdatetime_less_than_returns_false_when_lhs_after_rhs():
     later = utcdatetime(2016, 10, 7, 16, 0)
 
     assert_false(later < earlier)
+
+
+def test_later_minus_earlier_returns_positive_timedelta():
+    earlier = utcdatetime(2016, 10, 7, 15, 0)
+    later = utcdatetime(2016, 10, 7, 16, 0)
+
+    delta = later - earlier
+    assert_is_instance(delta, timedelta)
+    assert_equal(timedelta(hours=1), delta)
+
+
+def test_earlier_minutes_later_returns_negative_timedelta():
+    earlier = utcdatetime(2016, 10, 7, 15, 0)
+    later = utcdatetime(2016, 10, 7, 16, 0)
+
+    delta = earlier - later
+    assert_is_instance(delta, timedelta)
+    assert_equal(timedelta(hours=-1), delta)

--- a/utcdatetime/tests/test_add_subtract_compare.py
+++ b/utcdatetime/tests/test_add_subtract_compare.py
@@ -1,0 +1,85 @@
+from nose.tools import (
+    assert_equal, assert_not_equal, assert_true, assert_false
+)
+
+from datetime import timedelta
+from utcdatetime import utcdatetime
+
+
+UNEQUAL_TEST_CASES = [
+    ((2015, 6, 25, 16, 0, 0, 0), (2015, 6, 25, 16, 0, 0, 100)),  # microsec
+    ((2015, 6, 25, 16, 0, 0, 0), (2015, 6, 25, 16, 0, 1, 0)),    # sec
+    ((2015, 6, 25, 16, 0, 0, 0), (2015, 6, 25, 16, 1, 0, 0)),    # min
+    ((2015, 6, 25, 16, 0, 0, 0), (2015, 6, 25, 12, 1, 0, 0)),    # hour
+    ((2015, 6, 25, 16, 0, 0, 0), (2015, 6, 30, 16, 0, 0, 0)),    # day
+    ((2015, 6, 25, 16, 0, 0, 0), (2015, 5, 25, 16, 0, 0, 0)),    # month
+    ((2015, 6, 25, 16, 0, 0, 0), (1998, 5, 25, 16, 0, 0, 0)),    # year
+]
+
+
+def test_can_add_timedelta_to_utcdatetime():
+    got = utcdatetime(2016, 10, 7, 16, 0) + timedelta(minutes=15)
+    expected = utcdatetime(2016, 10, 7, 16, 15)
+    assert_equal(expected, got)
+
+
+def test_can_subtract_timedelta_from_utcdatetime():
+    got = utcdatetime(2016, 10, 7, 16, 0) - timedelta(minutes=15)
+    expected = utcdatetime(2016, 10, 7, 15, 45)
+    assert_equal(expected, got)
+
+
+def test_can_add_timedelta_with_plus_equals_operator():
+    dt = utcdatetime(2016, 10, 7, 16, 0)
+    dt += timedelta(minutes=15)
+
+    expected = utcdatetime(2016, 10, 7, 16, 15)
+    assert_equal(expected, dt)
+
+
+def test_can_add_timedelta_with_minus_equals_operator():
+    dt = utcdatetime(2016, 10, 7, 16, 0)
+    dt -= timedelta(minutes=15)
+
+    expected = utcdatetime(2016, 10, 7, 15, 45)
+    assert_equal(expected, dt)
+
+
+def test_utcdatetimes_compare_equal_when_equal():
+    assert_equal(
+        utcdatetime(2016, 10, 7, 15, 0),
+        utcdatetime(2016, 10, 7, 15, 0)
+    )
+
+
+def test_utcdatetimes_compare_not_equal_when_not_equal():
+    for a, b in UNEQUAL_TEST_CASES:
+        yield assert_not_equal, utcdatetime(*a), utcdatetime(*b)
+
+
+def test_utcdatetime_greater_than_returns_true_when_lhs_after_rhs():
+    earlier = utcdatetime(2016, 10, 7, 15, 0)
+    later = utcdatetime(2016, 10, 7, 16, 0)
+
+    assert_true(later > earlier)
+
+
+def test_utcdatetime_greater_than_returns_false_when_lhs_before_rhs():
+    earlier = utcdatetime(2016, 10, 7, 15, 0)
+    later = utcdatetime(2016, 10, 7, 16, 0)
+
+    assert_false(earlier > later)
+
+
+def test_utcdatetime_less_than_returns_true_when_lhs_before_rhs():
+    earlier = utcdatetime(2016, 10, 7, 15, 0)
+    later = utcdatetime(2016, 10, 7, 16, 0)
+
+    assert_true(earlier < later)
+
+
+def test_utcdatetime_less_than_returns_false_when_lhs_after_rhs():
+    earlier = utcdatetime(2016, 10, 7, 15, 0)
+    later = utcdatetime(2016, 10, 7, 16, 0)
+
+    assert_false(later < earlier)

--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -59,6 +59,8 @@ class utcdatetime(object):
     def __eq__(self, other):
         return self.__dt == other.__dt
 
-    def __isub__(self, delta):
-        self.__dt -= delta
-        return self
+    def __add__(self, delta):
+        return self.from_datetime(self.__dt + delta)
+
+    def __sub__(self, delta):
+        return self.from_datetime(self.__dt - delta)

--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -1,4 +1,5 @@
 import datetime
+from functools import total_ordering
 
 from .utc_timezone import UTC
 
@@ -6,6 +7,7 @@ FORMAT_NO_FRACTION = '%Y-%m-%dT%H:%M:%SZ'
 FORMAT_WITH_FRACTION = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 
+@total_ordering
 class utcdatetime(object):
     @classmethod
     def from_string(cls, string):
@@ -58,6 +60,9 @@ class utcdatetime(object):
 
     def __eq__(self, other):
         return self.__dt == other.__dt
+
+    def __lt__(self, other):
+        return self.__dt < other.__dt
 
     def __add__(self, delta):
         return self.from_datetime(self.__dt + delta)

--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -67,5 +67,12 @@ class utcdatetime(object):
     def __add__(self, delta):
         return self.from_datetime(self.__dt + delta)
 
-    def __sub__(self, delta):
-        return self.from_datetime(self.__dt - delta)
+    def __sub__(self, other):
+        if isinstance(other, datetime.timedelta):
+            return self.from_datetime(self.__dt - other)
+
+        if isinstance(other, utcdatetime):
+            return self.__dt - other.__dt
+
+        raise NotImplementedError("Can't do utcdatetime - type {}".format(
+            type(other)))

--- a/utcdatetime/utcdatetime.py
+++ b/utcdatetime/utcdatetime.py
@@ -74,5 +74,5 @@ class utcdatetime(object):
         if isinstance(other, utcdatetime):
             return self.__dt - other.__dt
 
-        raise NotImplementedError("Can't do utcdatetime - type {}".format(
+        raise TypeError("Can't do utcdatetime - type {}".format(
             type(other)))


### PR DESCRIPTION
Replaces #19 - thanks @gabrys for figuring this out.

The following was not possible before:

```
d = utcdatetime.now()
```

   print d + timedelta(days=1)
   print d - timedelta(days=1)
   d += timedelta(minutes=15)

Now it is.
